### PR TITLE
[noref] Run update_rdf only if it is not a dryrun, and pass release object directly

### DIFF
--- a/bin/release.ts
+++ b/bin/release.ts
@@ -134,9 +134,7 @@ async function getRelease(tag, prerelease) {
   }
 }
 
-async function update_rdf(releases_tag, failonerror) {
-  const release = await getRelease(releases_tag, false)
-
+async function update_rdf(release, failonerror) {
   const assets = (await octokit.repos.listReleaseAssets({ owner, repo, release_id: release.data.id })).data
 
   for (const asset of assets) {
@@ -173,10 +171,9 @@ async function main() {
     if (!dryRun) {
       release = await octokit.repos.createRelease({ owner, repo, tag_name: CI.tag, prerelease: !!PRERELEASE, body: process.argv[2] || '' })
       await uploadAsset(release, path.join(root, `xpi/${xpi}`), 'application/vnd.zotero.plugin')
+      // RDF update pointer(s)
+      update_rdf(release, true)
     }
-
-    // RDF update pointer(s)
-    update_rdf(CI.tag, true)
 
   } else if (issues.size) { // only release builds tied to issues
     release = await getRelease('builds', true)

--- a/bin/release.ts
+++ b/bin/release.ts
@@ -176,7 +176,7 @@ async function main() {
     }
 
     // RDF update pointer(s)
-    update_rdf(pkg.xpi.releaseURL.split('/').filter(name => name).reverse()[0], true)
+    update_rdf(CI.tag, true)
 
   } else if (issues.size) { // only release builds tied to issues
     release = await getRelease('builds', true)


### PR DESCRIPTION
Hi there,

I've been using your excellent plugin and noticed during our release that the `xpi` bundle was being properly added to the release, but the actual `update.rdf` was failing.

In the logs (we use `circleCI`, not `travis`), I saw:

```
#!/bin/bash -eo pipefail
npm run release


> zotero-scite@1.0.2 release /home/circleci/repo
> zotero-plugin-release

uploading zotero-scite-1.0.2.xpi to new release v1.0.2
uploading zotero-scite-1.0.2.xpi to v1.0.2
Could not get release release: HttpError: Not Found
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! zotero-scite@1.0.2 release: `zotero-plugin-release`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the zotero-scite@1.0.2 release script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/circleci/.npm/_logs/2020-11-13T00_08_37_646Z-debug.log


Exited with code exit status 1

CircleCI received exit code 1
```

Basically when it calls `getRelease(...)`, it errors saying `Could not get release release: HttpError: Not Found`.

I think the reason is that when `update_rdf(...)` is currently called, the logic it uses to find the `release_tag` is, for some reason, passing in `release` instead of the actual version (e.g. `v1.0.2`).

I noticed that currently `update_rdf` is called regardless of whether it's a `dryRun`. I wasn't sure if that should be the case, so I made the following changes:

- Call `update_rdf` only if it is not a `dryRun`
- Pass in `release` directly to `update_rdf` instead of trying to figure out the release tag from the `package.json` and use that directly (we already have it since we just did `createRelease`).
- Change the `update_rdf` method to take the `release` object instead of getting a `release_tag` and re-fetching the release

Obviously you have more context here than I do, so let me know if I missed anything and I'm more than happy to work with you on fixing this correctly.

(Thanks for reading all this and for your work here!)

- Ashish

EDIT:

If I'm being dumb and somehow not using this correctly let me know also...
