### PR TITLE
Extract tag with git describe instead of GITHUB_REF

### DIFF
--- a/continuous-integration.ts
+++ b/continuous-integration.ts
@@ -37,7 +37,7 @@ class ContinuousIntegrationSingleton {
 
       case 'GitHub':
         this.build_number = this.parseInt(process.env.GITHUB_RUN_NUMBER)
-        this.tag = process.env.GITHUB_REF.startsWith('refs/tags/') ? process.env.GITHUB_REF.split('/').pop() : null
+        this.tag = child_process.execSync(`git describe --exact-match ${process.env.GITHUB_SHA}`, {stdio: 'pipe' }).toString().trim()
         this.commit_message = child_process.execSync(`git log --format=%B -n 1 ${process.env.GITHUB_SHA}`).toString().trim()
         if (process.env.GITHUB_REF.startsWith('refs/heads/')) {
           this.branch = process.env.GITHUB_REF.split('/').pop()


### PR DESCRIPTION
In practice `GITHUB_REF` will contain the branch name and not the tag name, so that release process is never begin triggered.

Eg https://github.com/andrusha/zotero-scihub/runs/3165703004?check_suite_focus=true:
```
GITHUB_ACTIONS=true GITHUB_RUN_NUMBER=25 GITHUB_REF=refs/heads/master GITHUB_SHA=0d12cf4cf57f98a5b369c6b5c7130cb9c910efa6 GITHUB_EVENT_NAME=push
```

While
```
$ git describe --exact-match 0d12cf4cf57f98a5b369c6b5c7130cb9c910efa6
v1.0.5
```